### PR TITLE
增加支持直接配置渠道列表

### DIFF
--- a/ApkResigner.py
+++ b/ApkResigner.py
@@ -15,6 +15,7 @@ import sys
 import config
 import platform
 import shutil
+import argparse
 
 #获取脚本文件的当前路径
 def curFileDir():
@@ -84,6 +85,7 @@ keyAlias = config.keyAlias
 keystorePassword = config.keystorePassword
 keyPassword = config.keyPassword
 channelsOutputFilePath = parentPath + "channels"
+channelList = config.channelList
 channelFilePath = parentPath +"channel"
 protectedSourceApkPath = parentPath + config.protectedSourceApkName
 
@@ -97,6 +99,14 @@ if len(config.channelsOutputFilePath) > 0:
 
 if len(config.channelFilePath) > 0:
   channelFilePath = os.path.abspath(config.channelFilePath)
+
+# 读取命令携带的渠道列表参数，如果有读取到，则覆盖配置文件中的值
+parser = argparse.ArgumentParser(usage="python ApkResginer.py -c meituan,meituan2,meituan3", description="help info.")
+parser.add_argument("--channelList", "-c", help="The specified channel list configuration, if configured, has a higher priority than channelFilePath, and channelFilePath will be invalid. Channel names are separated by commas. -c is a short parameter, such as \"-c meituan,meituan2,meituan3\", --channelList= is a long parameter, such as \"--channelList=meituan,meituan2,meituan3\"", dest="channelList")
+# 将变量以标签-值的字典形式存入args字典
+args = parser.parse_args()
+if isinstance(args.channelList, str) and len(args.channelList) > 0:
+  channelList = args.channelList
 
 
 zipalignedApkPath = protectedSourceApkPath[0 : -4] + "_aligned.apk"
@@ -125,6 +135,8 @@ os.system(checkV2Shell)
 #写入渠道
 if len(config.extraChannelFilePath) > 0:
   writeChannelShell = "java -jar " + walleChannelWritterPath + " batch2 -f " + os.path.abspath(config.extraChannelFilePath) + " " + signedApkPath + " " + channelsOutputFilePath
+elif len(channelList) > 0:
+  writeChannelShell = "java -jar " + walleChannelWritterPath + " batch -c " + channelList + " " + signedApkPath + " " + channelsOutputFilePath
 else:
   writeChannelShell = "java -jar " + walleChannelWritterPath + " batch -f " + channelFilePath + " " + signedApkPath + " " + channelsOutputFilePath
 

--- a/ApkResigner.py
+++ b/ApkResigner.py
@@ -75,10 +75,11 @@ parentPath = curFileDir() + getBackslash()
 
 #config
 libPath = parentPath + "lib" + getBackslash()
-buildToolsPath =  config.sdkBuildToolPath + getBackslash()
+#所有从配置文件读取的路径使用os.path.abspath()转为绝对路径
+buildToolsPath =  os.path.abspath(config.sdkBuildToolPath) + getBackslash()
 checkAndroidV2SignaturePath = libPath + "CheckAndroidV2Signature.jar"
 walleChannelWritterPath = libPath + "walle-cli-all.jar"
-keystorePath = config.keystorePath
+keystorePath = os.path.abspath(config.keystorePath)
 keyAlias = config.keyAlias
 keystorePassword = config.keystorePassword
 keyPassword = config.keyPassword
@@ -89,13 +90,13 @@ protectedSourceApkPath = parentPath + config.protectedSourceApkName
 
 # 检查自定义路径，并作替换
 if len(config.protectedSourceApkDirPath) > 0:
-  protectedSourceApkPath = config.protectedSourceApkDirPath + getBackslash() + config.protectedSourceApkName
+  protectedSourceApkPath = os.path.abspath(config.protectedSourceApkDirPath) + getBackslash() + config.protectedSourceApkName
 
 if len(config.channelsOutputFilePath) > 0:
-  channelsOutputFilePath = config.channelsOutputFilePath
+  channelsOutputFilePath = os.path.abspath(config.channelsOutputFilePath)
 
 if len(config.channelFilePath) > 0:
-  channelFilePath = config.channelFilePath
+  channelFilePath = os.path.abspath(config.channelFilePath)
 
 
 zipalignedApkPath = protectedSourceApkPath[0 : -4] + "_aligned.apk"
@@ -123,7 +124,7 @@ os.system(checkV2Shell)
 
 #写入渠道
 if len(config.extraChannelFilePath) > 0:
-  writeChannelShell = "java -jar " + walleChannelWritterPath + " batch2 -f " + config.extraChannelFilePath + " " + signedApkPath + " " + channelsOutputFilePath
+  writeChannelShell = "java -jar " + walleChannelWritterPath + " batch2 -f " + os.path.abspath(config.extraChannelFilePath) + " " + signedApkPath + " " + channelsOutputFilePath
 else:
   writeChannelShell = "java -jar " + walleChannelWritterPath + " batch -f " + channelFilePath + " " + signedApkPath + " " + channelsOutputFilePath
 

--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ protectedSourceApkDirPath = ""
 channelsOutputFilePath = ""
 #渠道名配置文件路径，默认在此文件夹根目录
 channelFilePath = ""
-#额外信息配置文件（绝对路径，例如/Users/mac/Desktop/walle360/config.json）
+#额外信息配置文件（绝对路径或相对路径，例如/Users/mac/Desktop/walle360/config.json）
 #配置信息示例参看https://github.com/Meituan-Dianping/walle/blob/master/app/config.json
 extraChannelFilePath = ""
 #Android SDK buidtools path , please use above 25.0+

--- a/config.py
+++ b/config.py
@@ -3,21 +3,23 @@
 
 #keystore信息
 #Windows 下路径分割线请注意使用\\转义
-keystorePath = "..path/your.keystore"
-keyAlias = "your keyAlias"
-keystorePassword = "your keystorePassword"
-keyPassword = "your keyPassword"
+keystorePath = "epost_keys.keystore"
+keyAlias = "ePost"
+keystorePassword = "cxyapp"
+keyPassword = "cnpost"
 
 #加固后的源文件名（未重签名）
-protectedSourceApkName = "your protected.apk"
+protectedSourceApkName = "epost_encrypted.apk"
 #加固后的源文件所在文件夹路径(...path),注意结尾不要带分隔符，默认在此文件夹根目录
-protectedSourceApkDirPath = ""
+protectedSourceApkDirPath = "app/build/outputs"
 #渠道包输出路径，默认在此文件夹Channels目录下
-channelsOutputFilePath = ""
+channelsOutputFilePath = "app/build/outputs/channels/"
+#指定的渠道列表配置，如有配置，则它的优先级高于channelFilePath，channelFilePath将会失效。渠道名间用英文逗号分隔。如"meituan,meituan2,meituan3"
+channelList = ""
 #渠道名配置文件路径，默认在此文件夹根目录
-channelFilePath = ""
-#额外信息配置文件（绝对路径或相对路径，例如/Users/mac/Desktop/walle360/config.json）
+channelFilePath = "app/channel/"
+#额外信息配置文件（绝对路径，例如/Users/mac/Desktop/walle360/config.json）
 #配置信息示例参看https://github.com/Meituan-Dianping/walle/blob/master/app/config.json
 extraChannelFilePath = ""
 #Android SDK buidtools path , please use above 25.0+
-sdkBuildToolPath = "/Users/mac/Library/Android/sdk/build-tools/26.0.2"
+sdkBuildToolPath = "/home/ciUser/apps/android_sdk/build-tools/28.0.3"


### PR DESCRIPTION
根据walle命令增加支持直接配置渠道列表，增加ApkResigner.py支持携带渠道列表参数，以满足CI临时动态指定渠道列表打包的需求。python2.x版本正常。